### PR TITLE
chore: Update toolchain to nightly-2024-09-30

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         id: rustc-toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2024-08-01
+          toolchain: nightly-2024-09-30
           default: true
 
       - uses: lukka/get-cmake@v3.27.4


### PR DESCRIPTION
This matches the toolchain used by Jolt in this PR: https://github.com/a16z/jolt/pull/510

The compiler is updated to align with features used by Binius (in particular the use of `iter::repeat_n`)

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
