### PR TITLE
Fix grammatical error Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,7 @@ Zulip stream. We have lots of docs below of how to get started on your own, but
 the Zulip stream is the best place to *ask* for help.
 
 Documentation for contributing to the compiler or tooling is located in the [Guide to Rustc
-Development][rustc-dev-guide], commonly known as the [rustc-dev-guide]. Documentation for the
-standard library in the [Standard library developers Guide][std-dev-guide], commonly known as the [std-dev-guide].
+Development][rustc-dev-guide], commonly known as the [rustc-dev-guide]. Documentation for the standard library is located in the [Standard library developers Guide][std-dev-guide], commonly known as the [std-dev-guide].
 
 ## About the [rustc-dev-guide]
 


### PR DESCRIPTION
**Description:**  
In the section describing the standard library guide, there was a grammatical issue where a verb was missing, making the sentence incomplete. The sentence in question:

> "Documentation for the standard library in the [Standard library developers Guide][std-dev-guide], commonly known as the [std-dev-guide]"

lacked a verb, which made it sound awkward. The revised sentence is now:

> "Documentation for the standard library is located in the [Standard Library Developers Guide][std-dev-guide], commonly known as the [std-dev-guide]."

This fix improves the clarity and readability of the documentation. Correct grammar is crucial for ensuring that new contributors can easily understand the instructions.