### PR TITLE
Add riscv64im-jolt-zkvm-elf target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           ./configure \
             --set change-id="ignore" \
-            --target "${{ matrix.config.triple }},riscv32im-jolt-zkvm-elf,riscv64imac-jolt-zkvm-elf" \
+            --target "${{ matrix.config.triple }},riscv32im-jolt-zkvm-elf,riscv64im-jolt-zkvm-elf,riscv64imac-jolt-zkvm-elf" \
             --tools "cargo,cargo-clippy,clippy,rustfmt" \
             --release-channel="${{ matrix.channel }}" \
             --set rust.lld \
@@ -55,6 +55,7 @@ jobs:
         run: |
           export GITHUB_ACTIONS=false
           export CARGO_TARGET_RISCV32IM_JOLT_ZKVM_ELF_RUSTFLAGS="-Cpasses=lower-atomic"
+          export CARGO_TARGET_RISCV64IM_JOLT_ZKVM_ELF_RUSTFLAGS="-Cpasses=lower-atomic"
           ./x.py build --stage 2
         working-directory: rust
 

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1985,6 +1985,7 @@ supported_targets! {
     ("riscv32gc-unknown-linux-gnu", riscv32gc_unknown_linux_gnu),
     ("riscv32gc-unknown-linux-musl", riscv32gc_unknown_linux_musl),
     ("riscv64imac-jolt-zkvm-elf", riscv64imac_jolt_zkvm_elf),
+    ("riscv64im-jolt-zkvm-elf", riscv64im_jolt_zkvm_elf),
     ("riscv64imac-unknown-none-elf", riscv64imac_unknown_none_elf),
     ("riscv64gc-unknown-none-elf", riscv64gc_unknown_none_elf),
     ("riscv64gc-unknown-linux-gnu", riscv64gc_unknown_linux_gnu),

--- a/compiler/rustc_target/src/spec/targets/riscv64im_jolt_zkvm_elf.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv64im_jolt_zkvm_elf.rs
@@ -1,0 +1,47 @@
+use crate::spec::{
+    Cc, CodeModel, LinkerFlavor, Lld, PanicStrategy, RelocModel, SanitizerSet, Target,
+    TargetOptions,
+};
+
+pub(crate) fn target() -> Target {
+    Target {
+        data_layout: "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128".into(),
+        llvm_target: "riscv64".into(),
+        metadata: crate::spec::TargetMetadata {
+            description: Some("Jolt's Zero's zero-knowledge Virtual Machine (RV64IMC ISA)".into()),
+            tier: Some(3),
+            host_tools: Some(false),
+            std: None,
+        },
+        pointer_width: 64,
+        arch: "riscv64".into(),
+
+        options: TargetOptions {
+            os: "zkvm".into(),
+            vendor: "jolt".into(),
+            linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
+            linker: Some("rust-lld".into()),
+            cpu: "generic-rv64".into(),
+
+            // We claim to support atomics because our target is single threaded and non-preemptive,
+            // which means that all instructions are atomic already.
+            // We rely on llvm's "lower-atomics" pass to convert all atomic operations into the
+            // plain instructions.
+            max_atomic_width: Some(64),
+            atomic_cas: true,
+
+            executables: true,
+            features: "+m".into(),
+            llvm_abiname: "lp64".into(),
+            panic_strategy: PanicStrategy::Abort,
+            relocation_model: RelocModel::Static,
+            code_model: Some(CodeModel::Medium),
+            emit_debug_gdb_scripts: false,
+            eh_frame_header: false,
+            supported_sanitizers: SanitizerSet::KERNELADDRESS | SanitizerSet::SHADOWCALLSTACK,
+            singlethread: true,
+            supports_stack_protector: false,
+            ..Default::default()
+        },
+    }
+}

--- a/src/bootstrap/src/core/sanity.rs
+++ b/src/bootstrap/src/core/sanity.rs
@@ -38,6 +38,7 @@ const STAGE0_MISSING_TARGETS: &[&str] = &[
     "loongarch32-unknown-none-softfloat",
     "riscv32im-jolt-zkvm-elf",
     "riscv64imac-jolt-zkvm-elf",
+    "riscv64im-jolt-zkvm-elf",
 ];
 
 /// Minimum version threshold for libstdc++ required when using prebuilt LLVM

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -147,6 +147,7 @@ static TARGETS: &[&str] = &[
     "riscv32ima-unknown-none-elf",
     "riscv32imc-unknown-none-elf",
     "riscv64imac-jolt-zkvm-elf",
+    "riscv64im-jolt-zkvm-elf",
     "riscv32imac-unknown-none-elf",
     "riscv32imafc-unknown-none-elf",
     "riscv32gc-unknown-linux-gnu",


### PR DESCRIPTION
Atomics and compressed instructions bring considerable complexity into jolt-cpp implementation. We would like to avoid them at least initially. This new target allows us to build jolt examples using simpler instruction set.
