### PR TITLE
ci: fix script injection in outcome job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,7 +329,9 @@ jobs:
       # If all dependent jobs were successful, this exits with 0 (and the outcome job continues successfully).
       # If a some dependent job has failed, this exits with 1.
       - name: calculate the correct exit status
-        run: jq --exit-status 'all(.result == "success" or .result == "skipped")' <<< '${{ toJson(needs) }}'
+        env:
+          NEEDS_CONTEXT: ${{ toJson(needs) }}
+        run: jq --exit-status 'all(.result == "success" or .result == "skipped")' <<< "$NEEDS_CONTEXT"
       # Publish the toolstate if an auto build succeeds (just before push to master)
       - name: publish toolstate
         run: src/ci/publish_toolstate.sh


### PR DESCRIPTION
## Summary

Remediates a GitHub Actions script injection vulnerability (CWE-78) in the CI workflow's `outcome` job, identified by Wiz as issue `16f1da6f-ae19-4da7-9122-1f3e33ba5e10` (HIGH severity).

The `toJson(needs)` expression was interpolated directly into an inline `run:` script via a single-quoted here-string. Because `${{ }}` expressions are evaluated before the shell parser, any single-quote character in a `needs` output value (e.g., derived from a crafted commit message processed through `calculate_matrix`) would terminate the quoted string and yield arbitrary shell execution on the runner.

**Fix:** Move `toJson(needs)` to an `env:` block and reference the resulting shell variable. The runner's environment variable API sets the value without shell interpolation, eliminating the injection vector entirely.

## Change

```diff
- run: jq --exit-status '...' <<< '${{ toJson(needs) }}'
+ env:
+   NEEDS_CONTEXT: ${{ toJson(needs) }}
+ run: jq --exit-status '...' <<< "$NEEDS_CONTEXT"
```

## References

- Wiz Issue: `16f1da6f-ae19-4da7-9122-1f3e33ba5e10`
- Wiz Rule: `wc-id-3075` — Publicly exposed code repository with workflow script injection
- [GitHub Security Lab: Keeping your GitHub Actions and workflows secure](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/)